### PR TITLE
Fix code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,6 @@ share/python-wheels/
 MANIFEST
 
 # PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
 
@@ -55,18 +53,18 @@ cover/
 *.mo
 *.pot
 
-# Django stuff:
+# Django stuff
 *.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
-# Flask stuff:
+# Flask stuff
 instance/
 .webassets-cache
 
-# Scrapy stuff:
-.scrapy
+# Scrapy stuff
+.scrapy/
 
 # Sphinx documentation
 docs/_build/
@@ -76,52 +74,13 @@ docs/_build/
 target/
 
 # Jupyter Notebook
-.ipynb_checkpoints
+.ipynb_checkpoints/
 
 # IPython
 profile_default/
 ipython_config.py
 
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
+# Virtual Environments
 .env
 .venv
 env/
@@ -130,54 +89,51 @@ ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
+# Poetry
+poetry.lock
+.pdm.toml
+.pdm-python
+.pdm-build/
 
-# Rope project settings
-.ropeproject
+# PEP 582
+__pypackages__/
 
-# mkdocs documentation
-/site
+# Celery
+celerybeat-schedule
+celerybeat.pid
 
-# mypy
+# SageMath
+*.sage.py
+
+# Type checking
 .mypy_cache/
 .dmypy.json
 dmypy.json
-
-# Pyre type checker
 .pyre/
-
-# pytype static type analyzer
 .pytype/
 
-# Cython debug symbols
+# Cython
 cython_debug/
 
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+# IDEs
+.vscode/
+*.code-workspace
+.idea/
 
-# macOS files
+# macOS
 .DS_Store
 .AppleDouble
 .LSOverride
 
-# Windows files
+# Windows
 Thumbs.db
 ehthumbs.db
 Desktop.ini
 
-# VS Code
-.vscode/
-*.code-workspace
-
-# Docker
-.dockerignore
-docker-compose.override.yml
+# Logs and temp files
+*.log
+*.tmp
+*.bak
 
 # Node.js
 node_modules/
@@ -186,10 +142,32 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# Logs and temp
-*.log
-*.tmp
-*.bak
+# Docker
+.dockerignore
+docker-compose.override.yml
 
 # Git and CI/CD
 .coverage/
+.git/
+.sarif
+
+# CodeQL
+.codeql/cache/
+.codeql/results/
+.codeql/analysis/
+*.sarif
+
+# Snyk files
+snyk-report.json
+snyk.log
+
+# Secrets and sensitive files
+*.key
+*.pem
+*.env
+secrets.json
+
+# Miscellaneous
+*.swp
+*.lock
+.trash/

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ docker-compose.override.yml
 .sarif
 
 # CodeQL
+codeql-db/
 .codeql/cache/
 .codeql/results/
 .codeql/analysis/
@@ -171,3 +172,7 @@ secrets.json
 *.swp
 *.lock
 .trash/
+
+# Explicit inclusions
+!codeql-custom-queries-python/
+!codeql-custom-queries-python/**/*.ql

--- a/app/routes.py
+++ b/app/routes.py
@@ -59,7 +59,7 @@ def create_user():
         )
     except Exception as e:
         current_app.logger.error(f"Error in create_user: {e}", exc_info=True)
-        return jsonify({"error": f"An unexpected error occurred: {str(e)}"}), 500
+        return jsonify({"error": "An unexpected error occurred"}), 500
 
 
 @main.route("/users", methods=["GET"])

--- a/app/routes.py
+++ b/app/routes.py
@@ -5,6 +5,8 @@ from app.extensions import mongo
 
 main = Blueprint("main", __name__)
 
+ERROR_MESSAGE = "An unexpected error occurred"
+
 
 def validate_user_data(data):
     """
@@ -58,8 +60,8 @@ def create_user():
             201,
         )
     except Exception as e:
-        current_app.logger.error(f"Error in create_user: {e}", exc_info=True)
-        return jsonify({"error": "An unexpected error occurred"}), 500
+        current_app.logger.error(f"Error in create_user: {e}")
+        return jsonify({"error": ERROR_MESSAGE}), 500
 
 
 @main.route("/users", methods=["GET"])
@@ -81,7 +83,7 @@ def get_users():
         return jsonify(user_list), 200
     except Exception as e:
         current_app.logger.error(f"Error in get_users: {e}")
-        return jsonify({"error": "An unexpected error occurred"}), 500
+        return jsonify({"error": ERROR_MESSAGE}), 500
 
 
 @main.route("/users/<user_id>", methods=["GET"])
@@ -103,7 +105,7 @@ def get_user_by_id(user_id):
         return jsonify(user_data), 200
     except Exception as e:
         current_app.logger.error(f"Error in get_user_by_id: {e}")
-        return jsonify({"error": "An unexpected error occurred"}), 500
+        return jsonify({"error": ERROR_MESSAGE}), 500
 
 
 @main.route("/health", methods=["GET"])

--- a/codeql-custom-queries-python/codeql-pack.lock.yml
+++ b/codeql-custom-queries-python/codeql-pack.lock.yml
@@ -1,0 +1,26 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/dataflow:
+    version: 1.1.7
+  codeql/mad:
+    version: 1.0.13
+  codeql/python-all:
+    version: 3.0.0
+  codeql/regex:
+    version: 1.0.13
+  codeql/ssa:
+    version: 1.0.13
+  codeql/threat-models:
+    version: 1.0.13
+  codeql/tutorial:
+    version: 1.0.13
+  codeql/typetracking:
+    version: 1.0.13
+  codeql/util:
+    version: 2.0.0
+  codeql/xml:
+    version: 1.0.13
+  codeql/yaml:
+    version: 1.0.13
+compiled: false

--- a/codeql-custom-queries-python/codeql-pack.yml
+++ b/codeql-custom-queries-python/codeql-pack.yml
@@ -1,0 +1,7 @@
+---
+library: false
+warnOnImplicitThis: false
+name: getting-started/codeql-extra-queries-python
+version: 1.0.0
+dependencies:
+  codeql/python-all: ^3.0.0

--- a/codeql-custom-queries-python/example.ql
+++ b/codeql-custom-queries-python/example.ql
@@ -1,0 +1,12 @@
+/**
+ * This is an automatically generated file
+ * @name Hello world
+ * @kind problem
+ * @problem.severity warning
+ * @id python/example/hello-world
+ */
+
+import python
+
+from File f
+select f, "Hello, world!"


### PR DESCRIPTION
Fixes [https://github.com/kpeacocke/phatsurf/security/code-scanning/5](https://github.com/kpeacocke/phatsurf/security/code-scanning/5)

To fix the problem, we need to ensure that the detailed exception message is not included in the response sent to the user. Instead, we should return a generic error message while logging the detailed exception information on the server for debugging purposes. This can be achieved by modifying the error handling code to remove the exception message from the user-facing response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
